### PR TITLE
Use RemoteTraceback to output the cause of an exception when it is thrown

### DIFF
--- a/pebble/pool/process.py
+++ b/pebble/pool/process.py
@@ -19,6 +19,7 @@ import time
 from itertools import count
 from collections import namedtuple
 from multiprocessing import cpu_count
+from multiprocessing.pool import RemoteTraceback
 from signal import SIG_IGN, SIGINT, signal
 from concurrent.futures import CancelledError, TimeoutError
 try:
@@ -277,6 +278,8 @@ class TaskManager:
             if task.future.cancelled():
                 task.set_running_or_notify_cancel()
             elif isinstance(result, BaseException):
+                if hasattr(result, 'traceback'):
+                    result.__cause__ = RemoteTraceback(result.traceback)
                 task.future.set_exception(result)
             else:
                 task.future.set_result(result)

--- a/pebble/pool/process.py
+++ b/pebble/pool/process.py
@@ -19,7 +19,6 @@ import time
 from itertools import count
 from collections import namedtuple
 from multiprocessing import cpu_count
-from multiprocessing.pool import RemoteTraceback
 from signal import SIG_IGN, SIGINT, signal
 from concurrent.futures import CancelledError, TimeoutError
 try:
@@ -247,6 +246,17 @@ class PoolManager:
             return task_worker_lookup(running_tasks, worker_id)
         else:
             raise BrokenProcessPool("All workers expired")
+
+
+class RemoteTraceback(Exception):
+    """Hack to embed stringification of remote traceback in local traceback
+    Copied from multiprocessing.pool in Python >=3.4
+    """
+    def __init__(self, tb):
+        self.tb = tb
+
+    def __str__(self):
+        return self.tb
 
 
 class TaskManager:


### PR DESCRIPTION
We're using Pebble and were having difficulty debugging due to the stack trace of the original exception not being shown. The solution I took is the same one that is used in multiprocessing.pool.

Without this change, the information we got by default from an error within a process was something like:
  `AssertionError`

Now we get the full stacktrace:
```
Traceback (most recent call last):
  File "/Users/steven/.pyenv/versions/3.6.3/lib/python3.6/concurrent/futures/process.py", line 175, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/Users/steven/workspace/project/low_level_translation.py", line 237, in translate_to_settings
    settings = generate_settings(input)
  File "/Users/steven/workspace/project/low_level_translation.py", line 119, in generate_settings
    assert input.direction == output.direction
AssertionError
```