### PR TITLE
Possibility to stop thread & process worker

### DIFF
--- a/pebble/common.py
+++ b/pebble/common.py
@@ -121,6 +121,14 @@ class RemoteException(object):
         return rebuild_exception, (self.exception, self.traceback)
 
 
+class PebbleThread(Thread):
+    """Thread wrapper with flag to shutdown worker."""
+
+    def __init__(self, *args, **kwgs):
+        super(PebbleThread, self).__init__(*args, **kwgs)
+        self.is_shutdown = False
+
+
 def rebuild_exception(exception, traceback):
     exception.__cause__ = RemoteTraceback(traceback)
 
@@ -128,7 +136,7 @@ def rebuild_exception(exception, traceback):
 
 
 def launch_thread(name, function, *args, **kwargs):
-    thread = Thread(target=function, name=name, args=args, kwargs=kwargs)
+    thread = PebbleThread(target=function, name=name, args=args, kwargs=kwargs)
     thread.daemon = True
     thread.start()
 

--- a/pebble/pool/base_pool.py
+++ b/pebble/pool/base_pool.py
@@ -16,6 +16,7 @@
 
 import time
 import logging
+import weakref
 
 from threading import RLock
 from collections import namedtuple
@@ -139,6 +140,7 @@ class PoolContext(object):
 
 class Task:
     def __init__(self, identifier, future, timeout, payload):
+        future.task = weakref.ref(self)
         self.id = identifier
         self.future = future
         self.timeout = timeout

--- a/pebble/pool/process.py
+++ b/pebble/pool/process.py
@@ -132,6 +132,10 @@ class ProcessPool(BasePool):
 
         return map_future
 
+    def stop_worker(self, worker_id, force=False):
+        """Stops worker (if it's hung for example)."""
+        self._pool_manager.worker_manager.stop_worker(worker_id, force)
+
 
 def task_scheduler_loop(pool_manager):
     context = pool_manager.context


### PR DESCRIPTION
I would like to add feature to provide more high availability management.
In my project I really need to detect stuck futures (and workers) and remove them from pool.
Stuck code is headache, especially if you work with heavy ML & AI libs.
My strategy is to count stuck futures and restart application if their amount is more limit.
Together with stuck futures detection, I want to remove hang threads from pool, in order to give ability to start new workers.
That's why I need this patch & more flexibility in `pebble`.

My typical usage of it like:

```python
pool = pebble.ThreadPool() # pebble.ProcessPool()
future = pool.schedule(my_func)
if (future.task() and time.time() - future.task().timestamp > stuck_limit):
    pool.stop_worker(future.task().worker_id)
```