### PR TITLE
Allow a ProcessFuture access to actual process object.

### DIFF
--- a/pebble/common.py
+++ b/pebble/common.py
@@ -75,6 +75,10 @@ class PebbleFuture(Future):
 
 
 class ProcessFuture(PebbleFuture):
+    def __init__(self, process=None):
+        super(ProcessFuture, self).__init__()
+        self._process = process
+
     def cancel(self):
         """Cancel the future.
 

--- a/pebble/concurrent/process.py
+++ b/pebble/concurrent/process.py
@@ -69,7 +69,6 @@ def _process_wrapper(function, timeout, name):
 
     @wraps(function)
     def wrapper(*args, **kwargs):
-        future = ProcessFuture()
         reader, writer = Pipe(duplex=False)
 
         if get_start_method() != 'fork':
@@ -82,6 +81,8 @@ def _process_wrapper(function, timeout, name):
             name, _function_handler, target, args, kwargs, writer)
 
         writer.close()
+
+        future = ProcessFuture(worker)
 
         future.set_running_or_notify_cancel()
 


### PR DESCRIPTION
I have a need to wait for the concurrent process to finish, and there's currently no way to `.join()` the open process.
Added a reference from the returned future to the actual process object.