### PR TITLE
[WIP] Feature to avoid hang procs

### DIFF
--- a/pebble/pool/process.py
+++ b/pebble/pool/process.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pebble.  If not, see <http://www.gnu.org/licenses/>.
 
-import errno
 import os
 import signal
 import time

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,9 @@ setup(
     keywords="thread process pool decorator",
     url="https://github.com/noxdafox/pebble",
     packages=find_packages(exclude=["tests"]),
+    install_requires=[
+        "psutil==5.6.7",
+    ],
     extras_require={":python_version<'3'": ["futures"]},
     long_description=read('README.rst'),
     classifiers=[

--- a/test/test_process_pool_fork.py
+++ b/test/test_process_pool_fork.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import signal
+import platform
 import unittest
 import threading
 import multiprocessing
@@ -207,10 +208,15 @@ class TestProcessPool(unittest.TestCase):
 
     def test_process_pool_broken_initializer(self):
         """Process Pool Fork broken initializer is notified."""
+        py_version = platform.python_version()
         with self.assertRaises(RuntimeError):
             with ProcessPool(initializer=broken_initializer) as pool:
                 pool.active
-                time.sleep(0.4)
+                if py_version.startswith('3.4') or py_version.startswith('2.7'):
+                    # seems v2.7 & v3.4 affected by https://bugs.python.org/issue32057, because `time.sleep` doesn't wait
+                    os.system('sleep 0.4')
+                else:
+                    time.sleep(0.4)
                 pool.schedule(function)
 
     def test_process_pool_running(self):

--- a/test/test_process_pool_forkserver.py
+++ b/test/test_process_pool_forkserver.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import signal
+import platform
 import unittest
 import threading
 import multiprocessing
@@ -205,10 +206,15 @@ class TestProcessPool(unittest.TestCase):
 
     def test_process_pool_broken_initializer(self):
         """Process Pool Forkserver broken initializer is notified."""
+        py_version = platform.python_version()
         with self.assertRaises(RuntimeError):
             with ProcessPool(initializer=broken_initializer) as pool:
                 pool.active
-                time.sleep(1)
+                if py_version.startswith('3.4') or py_version.startswith('2.7'):
+                    # seems v2.7 & v3.4 affected by https://bugs.python.org/issue32057, because `time.sleep` doesn't wait
+                    os.system('sleep 1')
+                else:
+                    time.sleep(1)
                 pool.schedule(function)
 
     def test_process_pool_running(self):

--- a/test/test_process_pool_spawn.py
+++ b/test/test_process_pool_spawn.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import signal
+import platform
 import unittest
 import threading
 import multiprocessing
@@ -205,10 +206,15 @@ class TestProcessPool(unittest.TestCase):
 
     def test_process_pool_broken_initializer(self):
         """Process Pool Spawn broken initializer is notified."""
+        py_version = platform.python_version()
         with self.assertRaises(RuntimeError):
             with ProcessPool(initializer=broken_initializer) as pool:
                 pool.active
-                time.sleep(2)
+                if py_version.startswith('3.4') or py_version.startswith('2.7'):
+                    # seems v2.7 & v3.4 affected by https://bugs.python.org/issue32057, because `time.sleep` doesn't wait
+                    os.system('sleep 2')
+                else:
+                    time.sleep(2)
                 pool.schedule(function)
 
     def test_process_pool_running(self):


### PR DESCRIPTION
Hello @noxdafox ,

As I mentioned some time ago, working with `ProcessPool` made some headache for me due to hang & zombie processes. And this patch solved it in my case:

- 1st commit about zombies management, and despite of I can't repeat it, I used well-known recommendation http://www.microhowto.info/howto/reap_zombie_processes_using_a_sigchld_handler.html, and looked to python code in gunicorn, project which I intrust to.

- 2nd commit about slept child processes, which can stay after parent process finish. Example below helps to repeat it:

```python
import os
import time

from pebble import ProcessPool


def main():
    pid = os.fork()


pool = ProcessPool(max_workers=1)
with pool:
    pool.schedule(main)
time.sleep(10)
```

launch:

```
root@99085a9eeb5f:/# python proba.py&
[1] 1432
```

observe launched processes:

```
root@99085a9eeb5f:/# ps aux|grep python
root      1432  1.2  0.1 243732 16228 pts/0    S    09:10   0:00 python proba.py
root      1437  0.0  0.1  22432  9668 pts/0    S    09:10   0:00 python proba.py
root      1439  0.0  0.0   4832   892 pts/0    S+   09:10   0:00 grep python
```

observe after 10 sec:

```
root@99085a9eeb5f:/# ps aux|grep python
root      1437  0.0  0.1  22432  9668 pts/0    S    09:10   0:00 python proba.py
root      1441  0.0  0.0   4832   892 pts/0    S+   09:11   0:00 grep python
[1]+  Done                    python proba.py
```

let's see, what it waits for:

```
root@99085a9eeb5f:/# strace -p 1437
strace: Process 1437 attached
select(4, [3], [], [], NULL
```

As I understand, something wrong happens, because it forked after fork, which had lead to descriptors communication problem.



