### PR TITLE
remove unnecessary global statement

### DIFF
--- a/pebble/concurrent/process.py
+++ b/pebble/concurrent/process.py
@@ -163,8 +163,6 @@ _registered_functions = {}
 
 
 def _register_function(function):
-    global _registered_functions
-
     _registered_functions[_qualname(function)] = function
 
 


### PR DESCRIPTION
This global statement is not necessary because the function does not rebind the name anyway (there'll be no difference in the bytecode, but I think the source code is clearer without it).