### PR TITLE
more docs cleanup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include version.py LICENSE
+include LICENSE

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Pebble provides a neat API to manage threads and processes within an application
 
 :Source: https://github.com/noxdafox/pebble
 :Documentation: https://pebble.readthedocs.io
-:Download: https://pypi.python.org/pypi/pebble
+:Download: https://pypi.org/project/Pebble/
 
 |travis badge| |docs badge|
 
@@ -62,7 +62,7 @@ Pools support workers restart, timeout for long running tasks and more.
     from concurrent.futures import TimeoutError
 
     def function(foo, bar=0):
-    	return foo + bar
+        return foo + bar
 
     def task_done(future):
         try:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -287,7 +287,7 @@ Quite often developers need to integrate in their projects third party code whic
 Pools
 +++++
 
-The *ProcessPool* has been designed to support task timeouts and critical errors. If a task reaches its timeout, the worker will be interrupted immediately. Abrupt interruptions of the workers are dealt trasparently.
+The *ProcessPool* has been designed to support task timeouts and critical errors. If a task reaches its timeout, the worker will be interrupted immediately. Abrupt interruptions of the workers are dealt transparently.
 
 The *map* function returns a *Future* object to better control its execution. When the first result is ready, the *result* function will return an iterator. The iterator can be used to retrieve the results no matter their outcome.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -420,11 +420,7 @@ Is equivalent to ::
 Running the tests
 -----------------
 
-On Python 3, the tests will cover all the multiprocessing starting methods supported by the platform.
-
-Due to multiprocessing limitations, it is not possible to change the starting method once set. Therefore, test frameworks such as nose and pytest which run all the tests in a single process will fail.
-
-Please refer to the `test/run-test.sh` bash script to see how to run the tests.
+Please refer to the `.travis.yml` to see how to run the tests.
 
 .. _concurrent.futures.Future: https://docs.python.org/3/library/concurrent.futures.html#future-objects
 .. _multiprocessing.context: https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods


### PR DESCRIPTION
The `run-test.sh` file seems to be history since 5bb06f9
Removed that mention, and fixed up a few other minor things