### PR TITLE
fix packaging metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[bdist_wheel]
-universal = 1
-

--- a/setup.py
+++ b/setup.py
@@ -33,4 +33,5 @@ setup(
         "License :: OSI Approved :: " +
         "GNU Library or Lesser General Public License (LGPL)"
     ],
+    python_requires=">=3",
 )


### PR DESCRIPTION
With this change, when a wheel dist is next uploaded it would be tagged like `Pebble-5.0.2-py3-none-any.whl` instead of `Pebble-5.0.2-py2.py3-none-any.whl`

You may want to adjust the `python_requires` line in `setup.py` to rule out any old Python 3 versions too, but I'm not sure the appropriate minimum bound for pebble (maybe `python_requires=">=3.6"`?) so I'll leave that to you.

Unfortunately to fully fix #108 and prevent pip from collecting an incompatible release you also may want to "yank" 5.0.0 and 5.0.1 from PyPI (https://pypi.org/help/#yanked).