### PR TITLE
increase attempts for test_process_pool_stop_stopped_callback

### DIFF
--- a/test/test_process_pool_spawn.py
+++ b/test/test_process_pool_spawn.py
@@ -315,7 +315,7 @@ class TestProcessPool(unittest.TestCase):
             future = pool.schedule(function, args=[1])
             future.add_done_callback(stop_pool_callback)
             with self.assertRaises(RuntimeError):
-                for index in range(10):
+                for index in range(30):
                     time.sleep(0.1)
                     pool.schedule(long_function, args=[index])
 


### PR DESCRIPTION
On very slow machines, test_process_pool_stop_stopped_callback fails due to not raising a RuntimeError.  Increasing the number of long_function instances added to the pool causes it to perform as expected.