### PR TITLE
Fix RuntimeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ CWD = os.path.dirname(__file__)
 
 def package_version():
     module_path = os.path.join(CWD, 'pebble', '__init__.py')
-    for line in fileinput.input(module_path):
+    for line in fileinput.FileInput(module_path):
         if line.startswith('__version__'):
             return line.split('=')[-1].strip().replace('\'', '')
 


### PR DESCRIPTION
In our build environment the call to `fileinput.input()` throws
a `RuntimeError("input() already active")`. This solves the error
without impacting functionality.
