### PR TITLE
Add type-hinting to concurrent decorators. Bump to Python 3.9.

### DIFF
--- a/pebble/common/types.py
+++ b/pebble/common/types.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pebble.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Any
+from typing import Any, TypeVar
 from enum import Enum, IntEnum
 from dataclasses import dataclass
 from concurrent.futures import Future
@@ -26,8 +26,9 @@ class ProcessExpired(OSError):
         super(ProcessExpired, self).__init__(msg)
         self.exitcode = code
 
+_T = TypeVar("_T")
 
-class PebbleFuture(Future):
+class PebbleFuture(Future[_T]):
     # Same as base class, removed logline
     def set_running_or_notify_cancel(self):
         """Mark the future as running or process any cancel notifications.
@@ -64,9 +65,7 @@ class PebbleFuture(Future):
                 return True
             else:
                 raise RuntimeError('Future in unexpected state')
-
-
-class ProcessFuture(PebbleFuture):
+class ProcessFuture(PebbleFuture[_T]):
     def cancel(self):
         """Cancel the future.
 

--- a/pebble/concurrent/process.py
+++ b/pebble/concurrent/process.py
@@ -17,16 +17,30 @@
 import os
 import types
 import multiprocessing
+import multiprocessing.context
 
 from itertools import count
 from functools import wraps
-from typing import Any, Callable
+from typing import Any, Callable, Optional, TypeVar, Union, overload
 from concurrent.futures import CancelledError, TimeoutError
 
 from pebble import common
 
+_P = TypeVar("_P")
+_T = TypeVar("_T")
 
-def process(*args, **kwargs) -> Callable:
+@overload
+def process(func: Callable[[_P], _T]) -> Callable[[_P], common.ProcessFuture[_T]]: ...
+
+@overload
+def process(
+        name: Optional[str] = None,
+        daemon: bool = True,
+        timeout: Optional[float] = None,
+        mp_context: Optional[multiprocessing.context.BaseContext] = None
+    ) -> Callable[[Callable[[_P], _T]], Callable[[_P], common.ProcessFuture[_T]]]: ...
+
+def process(*args, **kwargs) -> Union[Callable[[_P], common.ProcessFuture[_T]], Callable[[Callable[[_P], _T]], Callable[[_P], common.ProcessFuture[_T]]]]:
     """Runs the decorated function in a concurrent process,
     taking care of the result and error management.
 

--- a/pebble/concurrent/thread.py
+++ b/pebble/concurrent/thread.py
@@ -14,14 +14,22 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Pebble.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Callable
+from typing import Callable, Optional, TypeVar, Union, overload
 from functools import wraps
 from concurrent.futures import Future
 
 from pebble import common
 
+_P = TypeVar("_P")
+_T = TypeVar("_T")
 
-def thread(*args, **kwargs) -> Callable:
+@overload
+def thread(func: Callable[[_P], _T]) -> Callable[[_P], Future[_T]]: ...
+
+@overload
+def thread(name: Optional[str] = None, daemon: bool = True) -> Callable[[Callable[[_P], _T]], Callable[[_P], Future[_T]]]: ...
+
+def thread(*args, **kwargs) -> Union[Callable[[_P], Future[_T]], Callable[[Callable[[_P], _T]], Callable[[_P], Future[_T]]]]:
     """Runs the decorated function within a concurrent thread,
     taking care of the result and error management.
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url="https://github.com/noxdafox/pebble",
     packages=find_packages(exclude=["test"]),
     long_description=open(os.path.join(CWD, 'README.rst')).read(),
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     classifiers=[
         "Programming Language :: Python :: 3",
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
I've confirmed before submitting this pull request that all tests pass.

This pull request does two things:
- It adds type-hinting, using generics, to the `thread` and `process` decorators in the `concurrent` sub-package. This allows users of this package to properly treat the output of a decorated function as a `Future` or `ProcessFuture`, respectively, instead of the type-checker treating the function signature as identical to the original function.
- It increments the minimum supported Python version of this package from 3.6 to 3.9 in order to support the generic type-hinting. The version for the next release will have to be increased regardless given that dataclasses were introduced in 3.7, and I believe going further to 3.9 will still cover many users.

I am a big fan of this package and would be eager to help add more type-hinting for the rest of the package as well as adding mypy/ruff linting!