### PR TITLE
Avoid deadlock on channel mutex when stopping pool

### DIFF
--- a/pebble/pool/process.py
+++ b/pebble/pool/process.py
@@ -189,7 +189,7 @@ def message_manager_loop(pool_manager: 'PoolManager'):
     context = pool_manager.context
 
     try:
-        # Keep pumping the message pipe as long as the pool manager does. In
+        # Keep pumping the message pipe as long as the pool manager lives. In
         # particular, during the pool stopping procedure we want to avoid any
         # worker from being blocked on writing to the pipe, as this would result
         # in deadlocking on the channel mutex.

--- a/test/test_process_pool_generic.py
+++ b/test/test_process_pool_generic.py
@@ -1,0 +1,35 @@
+from concurrent.futures import FIRST_COMPLETED, wait
+import time
+import unittest
+
+from pebble import ProcessPool
+from pebble.common.types import CONSTS
+from pebble.pool.base_pool import PoolStatus
+
+def function(argument, sleep_interval):
+    time.sleep(sleep_interval)
+    return argument
+
+class TestProcessPoolGeneric(unittest.TestCase):
+    def test_big_values_and_cancellation(self):
+        # Ideally this should be bigger than the multiprocessing pipe's internal
+        # buffer.
+        BIG_VALUE = [0] * 10 * 1000 * 1000
+        # The bigger number of workers is, the higher is the chance of catching
+        # bugs.
+        CNT = 50
+        # Let the worker events cluster around the sleep unit granularity to
+        # increase the chance of catching bugs.
+        INITIAL_SLEEP = CONSTS.sleep_unit * 10
+        EPS = CONSTS.sleep_unit / 10
+
+        futures = []
+        with ProcessPool(max_workers=CNT) as pool:
+            for i in range(CNT):
+                futures.append(pool.schedule(function, args=[BIG_VALUE, INITIAL_SLEEP + i * EPS]))
+            wait(futures, return_when=FIRST_COMPLETED)
+            for f in futures:
+                f.cancel()
+            time.sleep(EPS * CNT / 2)
+            pool.stop()
+            pool.join()

--- a/test/test_process_pool_generic.py
+++ b/test/test_process_pool_generic.py
@@ -58,7 +58,7 @@ class TestProcessPoolGeneric(unittest.TestCase):
             # Wait until the worker starts running the (spammy) task.
             while future._state == FutureStatus.PENDING:
                 time.sleep(0.1)
-            assert future._state == FutureStatus.RUNNING
+            self.assertEqual(future._state, FutureStatus.RUNNING)
 
             pool.stop()
             pool.join()


### PR DESCRIPTION
Let the message_manager_loop run at least until the PoolManager is fully stopped, to avoid the workers from hanging on writing to an (overflown) pipe while holding the channel mutex, which would result in a deadlock - causing a delay of 60 seconds, the BrokenProcessPool exception and an unclean shutdown of workers.

This fixes #147.