### PR TITLE
Use ParamSpec to forward type information in decorators

### DIFF
--- a/pebble/common/types.py
+++ b/pebble/common/types.py
@@ -22,7 +22,6 @@ from concurrent.futures import Future
 from typing import Any, TypeVar, Callable
 
 
-P = TypeVar("P")
 T = TypeVar("T")
 
 
@@ -185,17 +184,21 @@ class Consts:
 
 
 try:
-    CallableType = Callable[[P], T]
-    AsyncIODecoratorReturnType = Callable[[P], asyncio.Future[T]]
-    AsyncIODecoratorParamsReturnType = Callable[[Callable[[P], T]],
-                                                Callable[[P], asyncio.Future[T]]]
-    ThreadDecoratorReturnType = Callable[[P], Future[T]]
-    ThreadDecoratorParamsReturnType = Callable[[Callable[[P], T]],
-                                               Callable[[P], Future[T]]]
-    ProcessDecoratorReturnType = Callable[[P], ProcessFuture[T]]
-    ProcessDecoratorParamsReturnType = Callable[[Callable[[P], T]],
-                                                Callable[[P], ProcessFuture[T]]]
-except TypeError:
+    from typing_extensions import ParamSpec
+    P = ParamSpec("P")
+    CallableType = Callable[P, T]
+    AsyncIODecoratorReturnType = Callable[P, asyncio.Future[T]]
+    AsyncIODecoratorParamsReturnType = Callable[[Callable[P, T]],
+                                                Callable[P, asyncio.Future[T]]]
+    ThreadDecoratorReturnType = Callable[P, Future[T]]
+    ThreadDecoratorParamsReturnType = Callable[[Callable[P, T]],
+                                               Callable[P, Future[T]]]
+    ProcessDecoratorReturnType = Callable[P, ProcessFuture[T]]
+    ProcessDecoratorParamsReturnType = Callable[[Callable[P, T]],
+                                                Callable[P, ProcessFuture[T]]]
+except (TypeError, ImportError):
+    P = TypeVar("P")
+    CallableType = Callable
     ReturnType = Callable
     AsyncIODecoratorReturnType = Callable
     AsyncIODecoratorParamsReturnType = Callable


### PR DESCRIPTION
I noticed that mypy flagged type errors when using the pebble decorators, as it wasn't properly forwarding the type info, this change fixes that for python versions that support it.

A cleaner way might be to simply require python >= 3.10 and use ParamSpec directly, now that python 3.8 and 3.9 are both end-of-life