### PR TITLE
fix(channel): fix clearing `writer_mutex`

### DIFF
--- a/pebble/pool/channel.py
+++ b/pebble/pool/channel.py
@@ -196,7 +196,7 @@ class ChannelMutex:
         """Ensure named semaphores are cleaned up on Posix OSes using spawn."""
         del self.reader_mutex
         del self.writer_mutex
-        self.reader_mutex = self.reader_mutex = None
+        self.reader_mutex = self.writer_mutex = None
 
     @property
     @contextmanager


### PR DESCRIPTION
Fix a typo that resulted in `reader_mutex` being cleared twice, leaving `writer_mutex` assigned to a deleted mutex.

Fixes #164