### PR TITLE
Fix type annotation by replacing ``ModuleType`` with a ``MultiprocessingContext`` protocol

### DIFF
--- a/pebble/asynchronous/process.py
+++ b/pebble/asynchronous/process.py
@@ -18,17 +18,17 @@ from __future__ import annotations
 
 import os
 import asyncio
-import multiprocessing
 
 from itertools import count
 from functools import wraps
 from multiprocessing import connection
-from types import FunctionType, ModuleType
+from multiprocessing.process import BaseProcess
+from types import FunctionType
 from concurrent.futures import TimeoutError
 from typing import Any, Callable, overload
 
 from pebble import common
-from pebble.common.types import P, T
+from pebble.common.types import MultiprocessingContext, P, T
 from pebble.pool.process import ProcessPool
 
 
@@ -39,7 +39,7 @@ def process(
     name: str | None = None,
     daemon: bool = True,
     timeout: float | None = None,
-    mp_context: ModuleType | None = None,
+    mp_context: MultiprocessingContext | None = None,
     pool: ProcessPool | None = None,
 ) -> Callable[[Callable[P, T]], Callable[P, asyncio.Future[T]]]: ...
 def process(*args, **kwargs):
@@ -73,7 +73,7 @@ def _process_wrapper(
     name: str,
     daemon: bool,
     timeout: float,
-    mp_context: ModuleType,
+    mp_context: MultiprocessingContext,
     pool: ProcessPool | None,
 ) -> Callable:
     if isinstance(function, FunctionType):
@@ -104,7 +104,7 @@ def _process_wrapper(
         else:
             future: asyncio.Future = loop.create_future()
             reader, writer = mp_context.Pipe(duplex=False)
-            worker: multiprocessing.Process = common.launch_process(
+            worker: BaseProcess = common.launch_process(
                 name,
                 common.function_handler,
                 daemon,
@@ -125,7 +125,7 @@ def _process_wrapper(
 
 async def _worker_handler(
     future: asyncio.Future,
-    worker: multiprocessing.Process,
+    worker: BaseProcess,
     pipe: connection.Connection,
     timeout: float,
 ):

--- a/pebble/common/__init__.py
+++ b/pebble/common/__init__.py
@@ -1,6 +1,7 @@
 from pebble.common.types import FutureStatus, CONSTS
 from pebble.common.types import ProcessExpired, ProcessFuture
 from pebble.common.types import Result, ResultStatus, RemoteException
+from pebble.common.types import MultiprocessingContext
 from pebble.common.shared import decorate_function, execute, launch_thread
 from pebble.common.process import launch_process, stop_process, process_exit
 from pebble.common.process import register_function, maybe_install_trampoline

--- a/pebble/common/process.py
+++ b/pebble/common/process.py
@@ -24,21 +24,26 @@ import multiprocessing
 
 from traceback import format_exc
 from multiprocessing import connection
+from multiprocessing.process import BaseProcess
 from types import FunctionType, ModuleType
 from typing import Any, Callable, Iterable, Dict, Mapping
 
 from pebble.common.types import Result, ResultStatus, RemoteException, CONSTS, T, P
+from pebble.common.types import MultiprocessingContext
 
 
 def launch_process(
     name: str,
     function: Callable[P, T],
     daemon: bool,
-    mp_context: ModuleType,
+    mp_context: MultiprocessingContext,
     *args: P.args,
     **kwargs: P.kwargs,
-) -> multiprocessing.Process:
-    process: multiprocessing.Process = mp_context.Process(
+) -> BaseProcess:
+    # Process is deliberately absent from MultiprocessingContext: typeshed itself
+    # omits it from BaseContext since each start-method context declares it as a
+    # differently-typed ClassVar, which pyright cannot match structurally.
+    process: BaseProcess = mp_context.Process(  # type: ignore[attr-defined]
         target=function, name=name, args=args, kwargs=kwargs
     )
     process.daemon = daemon
@@ -47,7 +52,7 @@ def launch_process(
     return process
 
 
-def stop_process(process: multiprocessing.Process):
+def stop_process(process: BaseProcess):
     """Does its best to stop the process."""
     process.terminate()
     process.join(CONSTS.term_timeout)

--- a/pebble/common/types.py
+++ b/pebble/common/types.py
@@ -17,11 +17,36 @@
 from enum import Enum, IntEnum
 from dataclasses import dataclass
 from concurrent.futures import Future
-from typing import Any, ParamSpec, Generic, TypeVar
+from multiprocessing.connection import Connection
+from multiprocessing.synchronize import RLock as RLockType
+from typing import Any, ParamSpec, Generic, Protocol, Tuple, TypeVar
 
 
 T = TypeVar("T")
 P = ParamSpec("P")
+
+
+class MultiprocessingContext(Protocol):
+    """Structural type of the objects Pebble accepts as a multiprocessing context.
+
+    Either the multiprocessing module itself (the default) or a
+    multiprocessing.context.BaseContext instance returned by
+    multiprocessing.get_context(), such as SpawnContext, ForkContext
+    or ForkServerContext.
+
+    Process is intentionally not declared here: each start-method context
+    exposes it as a differently-typed ClassVar (e.g. SpawnContext.Process is
+    type[SpawnProcess]), which pyright cannot match structurally against a
+    single Protocol member. typeshed's own BaseContext omits it for the same
+    reason.
+
+    """
+
+    def Pipe(self, duplex: bool = True) -> Tuple[Connection, Connection]: ...
+
+    def RLock(self) -> RLockType: ...
+
+    def get_start_method(self) -> str: ...
 
 
 class ProcessExpired(OSError):

--- a/pebble/concurrent/process.py
+++ b/pebble/concurrent/process.py
@@ -17,17 +17,17 @@
 from __future__ import annotations
 
 import os
-import multiprocessing
 
 from itertools import count
 from functools import wraps
 from typing import Callable, overload
 from multiprocessing import connection
-from types import FunctionType, ModuleType
+from multiprocessing.process import BaseProcess
+from types import FunctionType
 from concurrent.futures import CancelledError, TimeoutError
 
 from pebble import common
-from pebble.common.types import P, T
+from pebble.common.types import MultiprocessingContext, P, T
 from pebble.pool.process import ProcessPool
 
 
@@ -38,7 +38,7 @@ def process(
     name: str | None = None,
     daemon: bool = True,
     timeout: float | None = None,
-    mp_context: ModuleType | None = None,
+    mp_context: MultiprocessingContext | None = None,
     pool: ProcessPool | None = None,
 ) -> Callable[[Callable[P, T]], Callable[P, common.ProcessFuture[T]]]: ...
 def process(*args, **kwargs):
@@ -72,7 +72,7 @@ def _process_wrapper(
     name: str,
     daemon: bool,
     timeout: float,
-    mp_context: ModuleType,
+    mp_context: MultiprocessingContext,
     pool: ProcessPool | None,
 ) -> Callable:
     if isinstance(function, FunctionType):
@@ -99,7 +99,7 @@ def _process_wrapper(
         else:
             future: common.ProcessFuture = common.ProcessFuture()
             reader, writer = mp_context.Pipe(duplex=False)
-            worker: multiprocessing.Process = common.launch_process(
+            worker: BaseProcess = common.launch_process(
                 name,
                 common.function_handler,
                 daemon,
@@ -124,7 +124,7 @@ def _process_wrapper(
 
 def _worker_handler(
     future: common.ProcessFuture,
-    worker: multiprocessing.Process,
+    worker: BaseProcess,
     pipe: connection.Connection,
     timeout: float,
 ):

--- a/pebble/pool/channel.py
+++ b/pebble/pool/channel.py
@@ -18,19 +18,19 @@
 import os
 import select
 
-from types import ModuleType
 from contextlib import contextmanager
 from multiprocessing import connection
 from typing import Any, Callable, Iterator
 
 from pebble.common import CONSTS
+from pebble.common.types import MultiprocessingContext
 
 
 class ChannelError(OSError):
     """Error occurring within the process channel."""
 
 
-def channels(mp_context: ModuleType) -> tuple:
+def channels(mp_context: MultiprocessingContext) -> tuple:
     read0, write0 = mp_context.Pipe(duplex=False)
     read1, write1 = mp_context.Pipe(duplex=False)
 
@@ -84,7 +84,7 @@ class WorkerChannel(Channel):
         reader: connection.Connection,
         writer: connection.Connection,
         unused_connections: tuple,
-        mp_context: ModuleType,
+        mp_context: MultiprocessingContext,
     ):
         super().__init__(reader, writer)
         self.mutex: ChannelMutex = ChannelMutex(mp_context)
@@ -141,7 +141,7 @@ class WorkerChannel(Channel):
 
 
 class ChannelMutex:
-    def __init__(self, mp_context: ModuleType):
+    def __init__(self, mp_context: MultiprocessingContext):
         # Not typing locks until multiprocessing and threading fixes it
         self.reader_mutex = mp_context.RLock()
         self.writer_mutex = mp_context.RLock() if os.name != "nt" else None

--- a/pebble/pool/process.py
+++ b/pebble/pool/process.py
@@ -25,11 +25,10 @@ import pickle
 import multiprocessing
 
 from queue import Queue
-from types import ModuleType
 from itertools import count
 from threading import Thread
 from dataclasses import dataclass
-from multiprocessing import Process
+from multiprocessing.process import BaseProcess
 from concurrent.futures.process import BrokenProcessPool
 from concurrent.futures import CancelledError, TimeoutError
 from typing import Any, Callable, Dict, Mapping, Iterable, Iterator, List, Tuple
@@ -41,7 +40,7 @@ from pebble.pool.base_pool import MapResults
 from pebble.pool.base_pool import PoolStatus, ProcessMapFuture, map_results
 from pebble.common import Result, ResultStatus, CONSTS
 from pebble.common import ProcessExpired, ProcessFuture
-from pebble.common.types import P, T
+from pebble.common.types import MultiprocessingContext, P, T
 from pebble.common import process_execute, launch_thread
 from pebble.common import launch_process, stop_process, process_exit
 
@@ -57,8 +56,8 @@ class ProcessPool(BasePool):
     initializer must be callable, if passed, it will be called
     every time a worker is started, receiving initargs as arguments.
 
-    The context parameter can be used to specify the multiprocessing.context object
-    used for starting the worker processes.
+    The context parameter can be used to specify the multiprocessing module
+    or the multiprocessing.context object used for starting the worker processes.
 
     """
 
@@ -68,7 +67,7 @@ class ProcessPool(BasePool):
         max_tasks: int = 0,
         initializer: Callable | None = None,
         initargs: Iterable[Any] = (),
-        context: ModuleType = multiprocessing,
+        context: MultiprocessingContext = multiprocessing,
     ):
         super().__init__(max_workers, max_tasks, initializer, initargs)
         self._pool_manager: PoolManager = PoolManager(self._context, context)
@@ -219,7 +218,7 @@ def message_manager_loop(pool_manager: PoolManager):
 class PoolManager:
     """Combines Task and Worker Managers providing a higher level one."""
 
-    def __init__(self, context: PoolContext, mp_context: ModuleType):
+    def __init__(self, context: PoolContext, mp_context: MultiprocessingContext):
         self.context: PoolContext = context
         self.task_manager: TaskManager = TaskManager(context.task_queue.task_done)
         self.worker_manager: WorkerManager = WorkerManager(
@@ -379,11 +378,16 @@ class WorkerManager:
     Maintains the workers active and encapsulates their communication logic.
     """
 
-    def __init__(self, workers: int, worker_parameters: Worker, mp_context: ModuleType):
-        self.workers: Dict[int, Process] = {}
+    def __init__(
+        self,
+        workers: int,
+        worker_parameters: Worker,
+        mp_context: MultiprocessingContext,
+    ):
+        self.workers: Dict[int, BaseProcess] = {}
         self.workers_number: int = workers
         self.worker_parameters: Worker = worker_parameters
-        self.mp_context: ModuleType = mp_context
+        self.mp_context: MultiprocessingContext = mp_context
         self.pool_channel: Channel | None = None
         self.workers_channel: WorkerChannel | None = None
 
@@ -414,7 +418,7 @@ class WorkerManager:
         Returns the workers which have unexpectedly ended.
 
         """
-        expired: Tuple[Process] = tuple(
+        expired: Tuple[BaseProcess] = tuple(
             w for w in dictionary_values(self.workers) if not w.is_alive()
         )
 
@@ -443,7 +447,7 @@ class WorkerManager:
 
     def new_worker(self):
         try:
-            worker: Process = launch_process(
+            worker: BaseProcess = launch_process(
                 WORKERS_NAME,
                 worker_process,
                 False,
@@ -555,7 +559,7 @@ def interpreter_shutdown():
     workers = [p for p in multiprocessing.active_children() if p.name == WORKERS_NAME]
 
     for worker in workers:
-        stop_process(worker)  # type: ignore[arg-type]
+        stop_process(worker)
 
 
 def dictionary_keys(dictionary: dict) -> tuple:


### PR DESCRIPTION
`ModuleType` is both too loose and factually wrong for the `context`/`mp_context` parameters: they also accept `multiprocessing.get_context()` results (e.g. `SpawnContext`), which are not `ModuleType` instances, as the existing tests already exercise.

Solution: Define a structural `MultiprocessingContext` protocol covering the members actually used (`Pipe`, `RLock` and `get_start_method`), and widen downstream `multiprocessing.Process` annotations to `BaseProcess` since `SpawnProcess`/`ForkProcess`/`ForkServerProcess` aren't subtypes of `multiprocessing.Process`.

`Process` is intentionally left out of the protocol: each start-method context declares it as a differently-typed mutable `ClassVar`, which pyright cannot match structurally against a single protocol member (typeshed's own `BaseContext` omits it for the same reason).

Fix mypy error that started appearing on our [CI tests](https://github.com/galaxyproject/galaxy/actions/runs/33876486609/job/101034586116) with the release of pebble 5.2.2:

```
galaxy/celery/__init__.py:179: error: Argument "context" to "ProcessPool" has
incompatible type "ForkServerContext"; expected Module  [arg-type]
    ...oncurrency, max_tasks=100, initializer=init_fork_pool, context=context
                                                                      ^~~~~~~
```

It can be also reproduced by checking a small script with pyright:

```python
from multiprocessing import get_context

import pebble

context = get_context("forkserver")
fork_pool = pebble.ProcessPool(context=context)
```

```
$ pyright test.py 
test.py
  test.py:6:40 - error: Argument of type "ForkServerContext" cannot be assigned to parameter "context" of type "ModuleType" in function "__init__"
    "ForkServerContext" is not assignable to "ModuleType" (reportArgumentType)
1 error, 0 warnings, 0 informations
```